### PR TITLE
About Message Improved

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -49,9 +49,9 @@
         <div class="about-title-box">
           <h3>About this title</h3>
 
-          <p><a href="/">Newspapers of New Zealand</a> is a catalogue of newspapers 
+          <p><a href="/">Newspapers of New Zealand</a> is a catalogue of all the newspapers 
             that have been published in New Zealand since 
-            the <a href="newspaper.html?id=2069">New Zealand Gazette and Wellington Spectator</a>in 1939.</a>
+            the <a href="newspaper.html?id=2069">New Zealand Gazette and Wellington Spectator</a> in 1839.</a>
           </p>
 
           <h3>Scope</h3>
@@ -65,7 +65,7 @@
             The data in this website is based on a subset of the New Zealand National Bibliography. 
             It was tidied up and annotated with references to online sources when possible (both manually and automatically)
             and published as the original 
-            <a href="https://web.archive.org/web/20200510114635/http://nznewspapers.appspot.com/about">Newspapers of New Zealand website</a> in .
+            <a href="https://web.archive.org/web/20200510114635/http://nznewspapers.appspot.com/about">Newspapers of New Zealand website</a> until it was taken down after Google retired some programs in 2020.
           </p>
           <p>
             The base data was from the Publications New Zealand Metadata Dataset created by 


### PR DESCRIPTION
About this title
Newspapers of New Zealand is a catalogue of all the newspapers that have been published in New Zealand since the New Zealand Gazette and Wellington Spectator in 1839.

Scope
Our definition of newspapers includes serial publications that are published in New Zealand for a general audience, and takes into account their frequency, appearance, and content.

Sources
The data in this website is based on a subset of the New Zealand National Bibliography. It was tidied up and annotated with references to online sources when possible (both manually and automatically) and published as the original Newspapers of New Zealand website until it was taken down after Google retired some programs in 2020.

The base data was from the Publications New Zealand Metadata Dataset created by the National Library of New Zealand and licensed under the Creative Commons Attribution 3.0 licence.

The most recent refresh of the PublicationsNZ data was in March 2013.

While the PublicationsNZ data is quite comprehensive, there are some omissions, inconsistencies, and even mistakes. These are tidied up as they are discovered.

Generally, the data for older records (pre-1950) is pretty good, but some more recent records (particularly for free community newspapers) can be patchy.

The newspaper records are being updated over time, and links to digital holdings added.